### PR TITLE
Add replace directive to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,8 @@
         "branch-alias": {
             "dev-master": "1.1-dev"
         }
+    },
+    "replace": {
+        "guzzlehttp/ringphp": "1.1.1"
     }
 }


### PR DESCRIPTION
We're using an older version of the Elasticsearch PHP package and not in a position to update [since we're using an older version of Elasticsearch](https://github.com/elastic/elasticsearch-php/tree/master#version-matrix). This would allow us to install your package so we can get rid of the Composer error: **Package guzzlehttp/ringphp is abandoned, you should avoid using it. No replacement was suggested.**

Since we're using an older version of the package, I realize we could just keep it as-is since the Guzzle package probably won't go anywhere. But we'd prefer to rely on a package officially endorsed by Elasticsearch, then use something that is clearly abandoned and may disappear.