### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/docs               export-ignore
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
Context: https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/

Recently by having elastic included via composer, and this package coming with it, unit tests in the production build are triggering static code scans to flag as security issues. By removing them from distributions through a .gitattributes file, there should be minimal impact while also making prod builds better.