### PR TITLE
Add replace guzzlehttp/ringphp in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "ext-curl": "*",
         "phpunit/phpunit": "~4.0"
     },
+    "replace": {
+        "guzzlehttp/ringphp": "self.version"
+    },
     "suggest": {
         "ext-curl": "Guzzle will use specific adapters if cURL is present"
     },


### PR DESCRIPTION
This would make `ezimuel/ringphp` work in combination with other packages that still require `guzzlehttp/ringphp`.
https://getcomposer.org/doc/04-schema.md#replace