### PR TITLE
Add attribute to avoid Deprecated notice

### DIFF
--- a/src/Future/CompletedFutureArray.php
+++ b/src/Future/CompletedFutureArray.php
@@ -11,31 +11,37 @@ class CompletedFutureArray extends CompletedFutureValue implements FutureArrayIn
         parent::__construct($result);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->result[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->result[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->result[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->result[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->result);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->result);

--- a/src/Future/FutureArray.php
+++ b/src/Future/FutureArray.php
@@ -8,31 +8,37 @@ class FutureArray implements FutureArrayInterface
 {
     use MagicFutureTrait;
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_value[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_value[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->_value[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_value[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_value);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->_value);


### PR DESCRIPTION
In PHP 8.1, >> non-final internal methods now require overriding methods to declare a [compatible return type](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal), otherwise a deprecated notice is emitted during inheritance validation.
RFC: https://wiki.php.net/rfc/internal_method_return_types

Because of this, we receive a deprecation notice when running our code with PHP8.1.

This PR adds #[ReturnTypeWillChange] attribute where it is needed, in order to avoid the described problem and keep backward compatibility.