### PR TITLE
fix(php8.1): Add explicit @return annotations to suppress User Deprecated notices (Symfony)

### DIFF
--- a/src/Future/BaseFutureTrait.php
+++ b/src/Future/BaseFutureTrait.php
@@ -47,6 +47,9 @@ trait BaseFutureTrait
         $this->cancelfn = $cancel;
     }
 
+    /**
+     * @return mixed
+     */
     public function wait()
     {
         if (!$this->isRealized) {
@@ -66,11 +69,17 @@ trait BaseFutureTrait
         return $this->result;
     }
 
+    /**
+     * @return PromiseInterface
+     */
     public function promise()
     {
         return $this->wrappedPromise;
     }
 
+    /**
+     * @return PromiseInterface
+     */
     public function then(
         callable $onFulfilled = null,
         callable $onRejected = null,

--- a/src/Future/CompletedFutureArray.php
+++ b/src/Future/CompletedFutureArray.php
@@ -12,36 +12,42 @@ class CompletedFutureArray extends CompletedFutureValue implements FutureArrayIn
     }
 
     #[\ReturnTypeWillChange]
+    /** @return bool */
     public function offsetExists($offset)
     {
         return isset($this->result[$offset]);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return mixed */
     public function offsetGet($offset)
     {
         return $this->result[$offset];
     }
 
     #[\ReturnTypeWillChange]
+    /** @return void */
     public function offsetSet($offset, $value)
     {
         $this->result[$offset] = $value;
     }
 
     #[\ReturnTypeWillChange]
+    /** @return void */
     public function offsetUnset($offset)
     {
         unset($this->result[$offset]);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return int */
     public function count()
     {
         return count($this->result);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return \ArrayIterator */
     public function getIterator()
     {
         return new \ArrayIterator($this->result);

--- a/src/Future/CompletedFutureArray.php
+++ b/src/Future/CompletedFutureArray.php
@@ -12,42 +12,54 @@ class CompletedFutureArray extends CompletedFutureValue implements FutureArrayIn
     }
 
     #[\ReturnTypeWillChange]
-    /** @return bool */
+    /**
+     * @return bool 
+     */
     public function offsetExists($offset)
     {
         return isset($this->result[$offset]);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return mixed */
+    /**
+     * @return mixed 
+     */
     public function offsetGet($offset)
     {
         return $this->result[$offset];
     }
 
     #[\ReturnTypeWillChange]
-    /** @return void */
+    /**
+     * @return void 
+     */
     public function offsetSet($offset, $value)
     {
         $this->result[$offset] = $value;
     }
 
     #[\ReturnTypeWillChange]
-    /** @return void */
+    /**
+     * @return void 
+     */
     public function offsetUnset($offset)
     {
         unset($this->result[$offset]);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return int */
+    /**
+     * @return int 
+     */
     public function count()
     {
         return count($this->result);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return \ArrayIterator */
+    /**
+     * @return \ArrayIterator 
+     */
     public function getIterator()
     {
         return new \ArrayIterator($this->result);

--- a/src/Future/CompletedFutureValue.php
+++ b/src/Future/CompletedFutureValue.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp\Ring\Future;
 
 use React\Promise\FulfilledPromise;
 use React\Promise\RejectedPromise;
+use React\Promise\PromiseInterface;
 
 /**
  * Represents a future value that has been resolved or rejected.
@@ -25,6 +26,9 @@ class CompletedFutureValue implements FutureInterface
         $this->error = $e;
     }
 
+    /**
+     * @return mixed
+     */
     public function wait()
     {
         if ($this->error) {
@@ -36,6 +40,9 @@ class CompletedFutureValue implements FutureInterface
 
     public function cancel() {}
 
+    /**
+     * @return PromiseInterface
+     */
     public function promise()
     {
         if (!$this->cachedPromise) {
@@ -47,6 +54,9 @@ class CompletedFutureValue implements FutureInterface
         return $this->cachedPromise;
     }
 
+    /**
+     * @return PromiseInterface
+     */
     public function then(
         callable $onFulfilled = null,
         callable $onRejected = null,

--- a/src/Future/FutureArray.php
+++ b/src/Future/FutureArray.php
@@ -9,36 +9,42 @@ class FutureArray implements FutureArrayInterface
     use MagicFutureTrait;
 
     #[\ReturnTypeWillChange]
+    /** @return bool */
     public function offsetExists($offset)
     {
         return isset($this->_value[$offset]);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return mixed */
     public function offsetGet($offset)
     {
         return $this->_value[$offset];
     }
 
     #[\ReturnTypeWillChange]
+    /** @return void */
     public function offsetSet($offset, $value)
     {
         $this->_value[$offset] = $value;
     }
 
     #[\ReturnTypeWillChange]
+    /** @return void */
     public function offsetUnset($offset)
     {
         unset($this->_value[$offset]);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return int */
     public function count()
     {
         return count($this->_value);
     }
 
     #[\ReturnTypeWillChange]
+    /** @return \ArrayIterator */
     public function getIterator()
     {
         return new \ArrayIterator($this->_value);

--- a/src/Future/FutureArray.php
+++ b/src/Future/FutureArray.php
@@ -9,42 +9,54 @@ class FutureArray implements FutureArrayInterface
     use MagicFutureTrait;
 
     #[\ReturnTypeWillChange]
-    /** @return bool */
+    /** 
+     * @return bool 
+     */
     public function offsetExists($offset)
     {
         return isset($this->_value[$offset]);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return mixed */
+    /** 
+     * @return mixed 
+     */
     public function offsetGet($offset)
     {
         return $this->_value[$offset];
     }
 
     #[\ReturnTypeWillChange]
-    /** @return void */
+    /** 
+     * @return void 
+     */
     public function offsetSet($offset, $value)
     {
         $this->_value[$offset] = $value;
     }
 
     #[\ReturnTypeWillChange]
-    /** @return void */
+    /** 
+     * @return void 
+     */
     public function offsetUnset($offset)
     {
         unset($this->_value[$offset]);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return int */
+    /** 
+     * @return int 
+     */
     public function count()
     {
         return count($this->_value);
     }
 
     #[\ReturnTypeWillChange]
-    /** @return \ArrayIterator */
+    /** 
+     * @return \ArrayIterator 
+     */
     public function getIterator()
     {
         return new \ArrayIterator($this->_value);


### PR DESCRIPTION
This PR suppresses Deprecated Notices generated by Symfony DebugClassLoader.php

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1662628/157150900-2d5f542c-23a9-4e40-a44c-4102fa6a29af.png">