### PR TITLE
Fix: PHP 8.1 deprecation warning

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -130,6 +130,9 @@ class CurlMultiHandler
             }
 
             do {
+                if ($this->active === null) { 
+                    $this->active = 0;
+                }
                 $mrc = curl_multi_exec($this->_mh, $this->active);
             } while ($mrc === CURLM_CALL_MULTI_PERFORM);
 


### PR DESCRIPTION
Uncaught Exception: Deprecated Functionality: curl_multi_exec(): Passing null to parameter #2 ($still_running) of type int is deprecated in vendor/ezimuel/ringphp/src/Client/CurlMultiHandler.php on line 133

Steps to reproduce:

$foo = curl_multi_init(); $still_running = null; curl_multi_exec($foo, 
$still_running);