### PR TITLE
Allow dynamic properties in CurlMultiHandler for PHP 8.2 support

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -16,6 +16,7 @@ use React\Promise\Deferred;
  *
  * @property resource $_mh Internal use only. Lazy loaded multi-handle.
  */
+#[AllowDynamicProperties]
 class CurlMultiHandler
 {
     /** @var callable */


### PR DESCRIPTION
Avoids the deprecation notice:

```
Deprecated: Creation of dynamic property GuzzleHttp\Ring\Client\CurlMultiHandler::$_mh is deprecated in /tmp/scout_elastic_test/vendor/ezimuel/ringphp/src/Client/CurlMultiHandler.php on line 47
```

Note: this PR does not fix or even check anything else with PHP 8.2 compatibility; just this specific issue.