### PR TITLE
Fix AllowDynamicProperties not working for PHP 8.2

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -16,7 +16,7 @@ use React\Promise\Deferred;
  *
  * @property resource $_mh Internal use only. Lazy loaded multi-handle.
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class CurlMultiHandler
 {
     /** @var callable */


### PR DESCRIPTION
Fix `#[\AllowDynamicProperties]` (added in #7) not working in CurlMultiHandler due to missing namespace qualifier

:man_facepalming: sorry, should've caught this earlier.