### PR TITLE
Fix AllowDynamicProperty for PHP8.2

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -16,7 +16,7 @@ use React\Promise\Deferred;
  *
  * @property resource $_mh Internal use only. Lazy loaded multi-handle.
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class CurlMultiHandler
 {
     /** @var callable */

--- a/src/Future/FutureArray.php
+++ b/src/Future/FutureArray.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Ring\Future;
 /**
  * Represents a future array value that when dereferenced returns an array.
  */
+#[\AllowDynamicProperties]
 class FutureArray implements FutureArrayInterface
 {
     use MagicFutureTrait;


### PR DESCRIPTION
Since the project uses namespaces, `#[AllowDynamicProperties]` need to be specified with a forward `\`. 