### PR TITLE
Promise 3.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "ezimuel/guzzlestreams": "^3.0.1",
-        "react/promise": "~2.0"
+        "react/promise": "~2.0 || ~3.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Future/CompletedFutureValue.php
+++ b/src/Future/CompletedFutureValue.php
@@ -1,9 +1,9 @@
 <?php
 namespace GuzzleHttp\Ring\Future;
 
-use React\Promise\FulfilledPromise;
-use React\Promise\RejectedPromise;
 use React\Promise\PromiseInterface;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 /**
  * Represents a future value that has been resolved or rejected.
@@ -47,8 +47,8 @@ class CompletedFutureValue implements FutureInterface
     {
         if (!$this->cachedPromise) {
             $this->cachedPromise = $this->error
-                ? new RejectedPromise($this->error)
-                : new FulfilledPromise($this->result);
+                ? \React\Promise\reject($this->error)
+                : \React\Promise\resolve($this->result);
         }
 
         return $this->cachedPromise;


### PR DESCRIPTION
This project can be marked as compatible with react/promise 3.x and 2.x by addressing a depreciation with FulfilledPromise and RejectedPromise classes.

These internal classes were marked as depreciated in 2.8.0 and to be removed in 3.0.0.
They are the only depreciated pieces of code that was removed in 3.0.0.

~~These changes have been tested with the latest version of opensearch-project/opensearch-php on PHP 8.1~~