### PR TITLE
Support of react/promise 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "ezimuel/guzzlestreams": "^3.0.1",
-        "react/promise": "~2.0"
+        "react/promise": "^2.0 || ^3.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Future/BaseFutureTrait.php
+++ b/src/Future/BaseFutureTrait.php
@@ -88,7 +88,7 @@ trait BaseFutureTrait
         return $this->wrappedPromise->then($onFulfilled, $onRejected, $onProgress);
     }
 
-    public function cancel()
+    public function cancel(): void
     {
         if (!$this->isRealized) {
             $cancelfn = $this->cancelfn;

--- a/src/Future/CompletedFutureValue.php
+++ b/src/Future/CompletedFutureValue.php
@@ -1,9 +1,10 @@
 <?php
 namespace GuzzleHttp\Ring\Future;
 
-use React\Promise\FulfilledPromise;
-use React\Promise\RejectedPromise;
 use React\Promise\PromiseInterface;
+
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 /**
  * Represents a future value that has been resolved or rejected.
@@ -38,7 +39,8 @@ class CompletedFutureValue implements FutureInterface
         return $this->result;
     }
 
-    public function cancel() {}
+    public function cancel(): void
+    {}
 
     /**
      * @return PromiseInterface
@@ -47,8 +49,8 @@ class CompletedFutureValue implements FutureInterface
     {
         if (!$this->cachedPromise) {
             $this->cachedPromise = $this->error
-                ? new RejectedPromise($this->error)
-                : new FulfilledPromise($this->result);
+                ? reject($this->error)
+                : resolve($this->result);
         }
 
         return $this->cachedPromise;
@@ -59,9 +61,8 @@ class CompletedFutureValue implements FutureInterface
      */
     public function then(
         ?callable $onFulfilled = null,
-        ?callable $onRejected = null,
-        ?callable $onProgress = null
+        ?callable $onRejected = null
     ) {
-        return $this->promise()->then($onFulfilled, $onRejected, $onProgress);
+        return $this->promise()->then($onFulfilled, $onRejected);
     }
 }

--- a/src/Future/FutureInterface.php
+++ b/src/Future/FutureInterface.php
@@ -2,7 +2,6 @@
 namespace GuzzleHttp\Ring\Future;
 
 use React\Promise\PromiseInterface;
-use React\Promise\PromisorInterface;
 
 /**
  * Represents the result of a computation that may not have completed yet.
@@ -16,7 +15,7 @@ use React\Promise\PromisorInterface;
  * computation has not yet completed when wait() is called, the call to wait()
  * will block until the future has completed.
  */
-interface FutureInterface extends PromiseInterface, PromisorInterface
+interface FutureInterface
 {
     /**
      * Returns the result of the future either from cache or by blocking until
@@ -37,4 +36,45 @@ interface FutureInterface extends PromiseInterface, PromisorInterface
      * Cancels the future, if possible.
      */
     public function cancel();
+
+    /**
+     * Transforms a promise's value by applying a function to the promise's fulfillment
+     * or rejection value. Returns a new promise for the transformed result.
+     *
+     * The `then()` method registers new fulfilled and rejection handlers with a promise
+     * (all parameters are optional):
+     *
+     *  * `$onFulfilled` will be invoked once the promise is fulfilled and passed
+     *     the result as the first argument.
+     *  * `$onRejected` will be invoked once the promise is rejected and passed the
+     *     reason as the first argument.
+     *  * `$onProgress` (deprecated) will be invoked whenever the producer of the promise
+     *     triggers progress notifications and passed a single argument (whatever it
+     *     wants) to indicate progress.
+     *
+     * It returns a new promise that will fulfill with the return value of either
+     * `$onFulfilled` or `$onRejected`, whichever is called, or will reject with
+     * the thrown exception if either throws.
+     *
+     * A promise makes the following guarantees about handlers registered in
+     * the same call to `then()`:
+     *
+     *  1. Only one of `$onFulfilled` or `$onRejected` will be called,
+     *      never both.
+     *  2. `$onFulfilled` and `$onRejected` will never be called more
+     *      than once.
+     *  3. `$onProgress` (deprecated) may be called multiple times.
+     *
+     * @param callable|null $onFulfilled
+     * @param callable|null $onRejected
+     * @return PromiseInterface
+     */
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null);
+
+    /**
+     * Returns the promise of the deferred.
+     *
+     * @return PromiseInterface
+     */
+    public function promise();
 }


### PR DESCRIPTION
This PR allows the usage of react/promise 2.0 and 3.0. I needed to refactor the code to use only the `FutureInterface` with no extended interfaces from react/promise.